### PR TITLE
Relax requirement for symfony/processm allow 3.3.10 and higher minor versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "codeception/codeception": "~2.3",
         "composer/semver": "~1.4.2",
         "ocramius/package-versions": "~1.1.3",
-        "symfony/process": "~3.3.10 || ~2.7"
+        "symfony/process": "^3.3.10 || ~2.7"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~3.0.2",


### PR DESCRIPTION
fix a conflict when also using typo3 console which requires symfony/process=^3.4 in recent versions.